### PR TITLE
Vip 1: Improve Anti-Bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /protocol/build
+node_modules

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -24,7 +24,7 @@ library Constants {
     uint256 private constant CHAIN_ID = 1; // Mainnet
 
     /* Bootstrapping */
-    uint256 private constant BOOTSTRAPPING_PERIOD = 36; // 60 epochs IMPORTANT
+    uint256 private constant BOOTSTRAPPING_PERIOD = 36; // 36 epochs IMPORTANT
     uint256 private constant BOOTSTRAPPING_PERIOD_PHASE1 = 11; // 12 epochs to speed up deployment IMPORTANT
     uint256 private constant BOOTSTRAPPING_PRICE = 172e16; // 1.72 pegged token (targeting 6% inflation)
 
@@ -43,7 +43,7 @@ library Constants {
     uint256 private constant EPOCH_GROWTH_CONSTANT = 12000; //3.3 hrs
     uint256 private constant P1_EPOCH_BASE = 300; // IMPORTANT
     uint256 private constant P1_EPOCH_GROWTH_CONSTANT = 2000; // IMPORTANT
-    uint256 private constant ADVANCE_LOTTERY_TIME = 120; // 2 minutes
+    uint256 private constant ADVANCE_LOTTERY_TIME = 91; // 7 average block lengths
 
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 12; // 1 dayish governance period IMPORTANT

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -26,7 +26,7 @@ library Constants {
     /* Bootstrapping */
     uint256 private constant BOOTSTRAPPING_PERIOD = 36; // 36 epochs IMPORTANT
     uint256 private constant BOOTSTRAPPING_PERIOD_PHASE1 = 11; // 12 epochs to speed up deployment IMPORTANT
-    uint256 private constant BOOTSTRAPPING_PRICE = 172e16; // 1.72 pegged token (targeting 6% inflation)
+    uint256 private constant BOOTSTRAPPING_PRICE = 196e16; // 1.96 pegged token (targeting 8% inflation)
 
     /* Oracle */
     //pegs to DSD during bootstrap. variable name not renamed on purpose until DAO votes on the peg.
@@ -53,7 +53,7 @@ library Constants {
 
     /* DAO */
     uint256 private constant ADVANCE_INCENTIVE = 50e18; // 50 VTD
-    uint256 private constant ADVANCE_INCENTIVE_BOOTSTRAP = 100e18; // 100 VTD during phase 1 bootstrap
+    uint256 private constant ADVANCE_INCENTIVE_BOOTSTRAP = 50e18; // 100 VTD during phase 1 bootstrap
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 18; // 18 epoch fluid IMPORTANT
 
     /* Pool */

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -46,7 +46,7 @@ library Constants {
     uint256 private constant ADVANCE_LOTTERY_TIME = 91; // 7 average block lengths
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 12; // 1 dayish governance period IMPORTANT
+    uint256 private constant GOVERNANCE_PERIOD = 8; // 1 dayish governance period IMPORTANT
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 51e16; // 51%
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 21600; // 6 hours

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -28,6 +28,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     using SafeMath for uint256;
 
     bytes32 private constant FILE = "DAO";
+    uint private lastLuckyNumber = 6;
 
     event Advance(uint256 indexed epoch, uint256 block, uint256 timestamp);
     event Incentivization(address indexed account, uint256 amount);
@@ -55,9 +56,11 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         emit Advance(epoch(), block.number, block.timestamp);
     }
 
-    function genRandom() private view returns (uint8) {
-        uint rand = uint(keccak256(abi.encodePacked(blockhash(block.number-1))));
-        return uint8(rand % Constants.getAdvanceLotteryTime());
+    function genRandom() private returns (uint8) {
+        uint randomnumber = uint(keccak256(abi.encodePacked(blockhash(block.number-1), msg.sender, lastLuckyNumber)));
+        uint8 rand = uint8(randomnumber % Constants.getAdvanceLotteryTime());
+        lastLuckyNumber= rand+1;        
+        return rand;
     }
 
     modifier incentivized {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -39,6 +39,12 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     }
 
     function tryAdvance() external {
+        Require.that(
+            tx.gasprice <= 300e9, //prevent 12k gas bots, max is 300gwei
+            FILE,
+            "Gas too high"
+        );
+
         if (blockTimestamp() > nextEpochTimestamp().add(genRandom())) {
             advanceEpoch();
         }  

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -35,7 +35,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
 
     function initialize() initializer public {
-        initializeEpochTimestamp();
     }
 
     function tryAdvance() external {
@@ -58,9 +57,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function genRandom() private view returns (uint8) {
         uint rand = uint(keccak256(abi.encodePacked(blockhash(block.number-1))));
-        if (phaseOneAt(epoch())){
-            return 1; //prevents random time being greater than epoch time
-        }
         return uint8(rand % Constants.getAdvanceLotteryTime());
     }
 

--- a/protocol/migrations/2_deploy.js
+++ b/protocol/migrations/2_deploy.js
@@ -10,20 +10,20 @@ async function deployTestnetUSDC(deployer) {
 }
 
 async function deployTestnet(deployer) {
-  const d1 = await deployer.deploy(Deployer1);
-  const root = await deployer.deploy(Root, d1.address);
-  const rootAsD1 = await Deployer1.at(root.address);
+  // const d1 = await deployer.deploy(Deployer1);
+  // const root = await deployer.deploy(Root, d1.address);
+  // const rootAsD1 = await Deployer1.at(root.address);
 
-  const d2 = await deployer.deploy(Deployer2);
-  await rootAsD1.implement(d2.address);
-  const rootAsD2 = await Deployer2.at(root.address);
+  // const d2 = await deployer.deploy(Deployer2);
+  // await rootAsD1.implement(d2.address);
+  // const rootAsD2 = await Deployer2.at(root.address);
 
-  const d3 = await deployer.deploy(Deployer3);
-  await rootAsD2.implement(d3.address);
-  const rootAsD3 = await Deployer3.at(root.address);
+  // const d3 = await deployer.deploy(Deployer3);
+  // await rootAsD2.implement(d3.address);
+  // const rootAsD3 = await Deployer3.at(root.address);
 
   const implementation = await deployer.deploy(Implementation);
-  await rootAsD3.implement(implementation.address);
+  // await rootAsD3.implement(implementation.address);
 }
 
 module.exports = function(deployer) {


### PR DESCRIPTION
This candidate improves the pseudo random number generation, and includes some initial deployment code cleanups in order to upgrade.

The idea with the pseudo number lottery is not to make it impossible for the bot to guess (which would require an offchain oracle), but rather, to improve your chances against the bot. Because the winning ticket is different for each person, and the bot has only 7 blocks to beat you by brute force. 

Shortening the lottery period also reduces the number of attempts a bot can try, while not hurting the humans who only have time for one attempt. 

---
Also shortens the governance period in anticipation of a future vote on the pegged token.

--Implementation address: https://etherscan.io/address/0xc567b6164Ea86608D238138A8b187Db0103e1B8c#contracts--
Updated:

Added new tweaks as per community sugguestions. 
- limit gas to prevent 12k gas bots
- reduce rewards to 50
- increase bootstrap expansion to 8%

Implementation: https://etherscan.io/address/0x12a015E9b3418d2E33d963Ee1f1A955FD717103B#contracts


