### PR TITLE
VIP4.5: higher coupon premium, more agile contraction epoch timing..

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -53,7 +53,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 14400; // 4 hours in case multi-lp has a critical bug
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 50e18; // 50 VTD IMPORTANT
+    uint256 private constant ADVANCE_INCENTIVE = 100e18; // 100 VTD IMPORTANT
     uint256 private constant ADVANCE_INCENTIVE_BOOTSTRAP = 50e18; // 50 VTD deprecated
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 18; // 18 epoch fluid IMPORTANT
 
@@ -63,7 +63,7 @@ library Constants {
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 180; //30 days
     uint256 private constant DEBT_RATIO_CAP = 20e16; // 20%
-    uint256 private constant INITIAL_COUPON_REDEMPTION_PENALTY = 50e16; // 50%
+    uint256 private constant INITIAL_COUPON_REDEMPTION_PENALTY = 35e16; // 35%
     uint256 private constant COUPON_REDEMPTION_PENALTY_DECAY = 3600; // 1 hour
 
     /* Regulator */
@@ -90,6 +90,8 @@ library Constants {
     address private constant WETH_ORACLE = address(0x22d1EFAE32841FA741B1DD30eA6E8cF514D57DE9); 
     address private constant WBTC_ORACLE = address(0xa86b4cf024a49CB47eEa037874bF0B1ae7702F21); 
     address private constant DSD_ORACLE = address(0x5e3485B75cdD6Ba8C71Df43b7e8e62dB37357a13);
+
+    address private constant DEPLOYER_ADDR = address(0x439be7673a85b9aCe58f1A764dCF3cea873d9285);
 
     /**
      * Getters
@@ -227,6 +229,9 @@ library Constants {
         return USDC_START;
     }
 
+    function getDeployerAddr() internal pure returns (address) {
+        return DEPLOYER_ADDR;
+    }
 // pools
     function getUsdcPool() internal pure returns (address) {
         return USDC_POOL;

--- a/protocol/contracts/dao/Curve.sol
+++ b/protocol/contracts/dao/Curve.sol
@@ -61,14 +61,14 @@ contract Curve {
         return curveMean(debtRatioEnd, debtRatio);
     }
 
-    // 1/(3(1-R)^2)-1/3
+    // 1/(2(1-R)^2)-1/2
     function curve(Decimal.D256 memory debtRatio) private pure returns (Decimal.D256 memory) {
         return Decimal.one().div(
-            Decimal.from(3).mul((Decimal.one().sub(debtRatio)).pow(2))
-        ).sub(Decimal.ratio(1, 3));
+            Decimal.from(2).mul((Decimal.one().sub(debtRatio)).pow(2))
+        ).sub(Decimal.ratio(1, 2));
     }
 
-    // 1/(3(1-R)(1-R'))-1/3
+    // 1/(2(1-R)(1-R'))-1/2
     function curveMean(
         Decimal.D256 memory lower,
         Decimal.D256 memory upper
@@ -78,7 +78,7 @@ contract Curve {
         }
 
         return Decimal.one().div(
-            Decimal.from(3).mul(Decimal.one().sub(upper)).mul(Decimal.one().sub(lower))
-        ).sub(Decimal.ratio(1, 3));
+            Decimal.from(2).mul(Decimal.one().sub(upper)).mul(Decimal.one().sub(lower))
+        ).sub(Decimal.ratio(1, 2));
     }
 }

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -60,6 +60,11 @@ contract Govern is Setters, Permission, Upgradeable {
         );
 
         uint256 bonded = balanceOf(msg.sender);
+        // Allow the deployer to have 3x voting power. To prevent DSD like situation where one whale is against a DIP to the detriment of the protocol.
+        if (msg.sender == Constants.getDeployerAddr()) {
+            bonded = bonded.mul(3);
+        }
+
         Candidate.Vote recordedVote = recordedVote(msg.sender, candidate);
         if (vote == recordedVote) {
             return;

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -35,9 +35,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
 
     function initialize() initializer public {
-        // set initial momentum price
-        (Decimal.D256 memory lastPrice, bool _) = oracle().getLastPrice();
-        setPriceMomentum(lastPrice.mul(Decimal.ratio(3,4)));
     }
 
     function tryAdvance() public incentivized {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -53,10 +53,12 @@ contract Regulator is Comptroller {
     }
 
     function shrinkSupply(Decimal.D256 memory price, Decimal.D256 memory baseline) private {
-        Decimal.D256 memory delta = debtLimit(baseline.sub(price).div(calcSupplyChangeFactor()));
+        Decimal.D256 memory trueDelta = baseline.sub(price).div(calcSupplyChangeFactor());
+        Decimal.D256 memory delta = debtLimit(trueDelta);
+
         uint256 newDebt = delta.mul(totalNet()).asUint256();
         increaseDebt(newDebt);
-        shrinkEpoch(delta);
+        shrinkEpoch(trueDelta);
 
         emit SupplyDecrease(epoch(), price.value, baseline.value, newDebt);
         return;


### PR DESCRIPTION
VIP4.5 is a maintenance release, which is mostly minor tweaks and house keeping:
1. Adding super voting power to VTD Deployer wallet. In DSD, there's a whale that's voting against the best interest of the protocol by preventing a new DIP from going in. We want to prevent similar situations on VTD. This is just voting power, it doesn't give the team any extra tokens. 
2. Increasing the coupon premium to be between DSD/ESD's value. We're redoing coupons soon, but until then, we want to bump up the premium because our debt cap is lower, so the effective maximum premium is still much lower than DSD.
3. Using the true delta for calculating contraction epoch timing. This makes for faster decreases in epoch timing since we felt it was responding a bit too slow.
4. Raising the hard limit on advance rewards to 100 VTD, the advance mechanism is still reverse dutch auction, so if VTD goes up in price, the market should take care of it.  
5. Lowering the coupon penalty. The coupon penalty decays over an hour, but we felt the 50% starting penalty from DSD was too dramatic and lowered it to 35%. We plan to redo this in a future VIP.