### PR TITLE
VIP4.6: more sensitive momentum, better price delta algo, prepare usdt

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -53,7 +53,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 14400; // 4 hours in case multi-lp has a critical bug
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 100e18; // 100 VTD IMPORTANT
+    uint256 private constant ADVANCE_INCENTIVE = 300e18; // 300 VTD IMPORTANT
     uint256 private constant ADVANCE_INCENTIVE_BOOTSTRAP = 50e18; // 50 VTD deprecated
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 18; // 18 epoch fluid IMPORTANT
 
@@ -77,6 +77,7 @@ library Constants {
     uint256 private constant USDC_START = 240;
     uint256 private constant USDT_START = 120;
     uint256 private constant WBTC_START = 180;
+    uint256 private constant DSD_END = 150;
 
     // IMPORTANT, double check addresses
     address private constant USDC_POOL = address(0xD3DD32395271bAC888dAAF58Aa7FAF635D6d459F);
@@ -227,6 +228,10 @@ library Constants {
 
     function getUsdcStart() internal pure returns (uint256) {
         return USDC_START;
+    }
+
+    function getDsdEnd() internal pure returns (uint256) {
+        return DSD_END;
     }
 
     function getDeployerAddr() internal pure returns (address) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -77,7 +77,7 @@ library Constants {
     uint256 private constant USDC_START = 240;
     uint256 private constant USDT_START = 120;
     uint256 private constant WBTC_START = 180;
-    uint256 private constant DSD_END = 150;
+    uint256 private constant DSD_END = 130;
 
     // IMPORTANT, double check addresses
     address private constant USDC_POOL = address(0xD3DD32395271bAC888dAAF58Aa7FAF635D6d459F);

--- a/protocol/contracts/dao/PeggingSystem.sol
+++ b/protocol/contracts/dao/PeggingSystem.sol
@@ -49,6 +49,10 @@ contract PeggingSystem is Setters{
             usdcLiquidity = 0;
         }
 
+        if (epoch() > Constants.getDsdEnd()) {
+            dsdLiquidity = 0;
+        }
+
         uint256 totalLiquidity = dsdLiquidity.add(usdtLiquidity).add(ethLiquidity).add(wbtcLiquidity).add(usdcLiquidity);
         if (totalLiquidity == 0) {
             totalLiquidity = 1; //prevent division by zero

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -67,7 +67,7 @@ contract Regulator is Comptroller {
     }
 
     function growSupply(Decimal.D256 memory price, Decimal.D256 memory baseline) private {
-        Decimal.D256 memory delta = limit(price.sub(baseline).div(price).div(calcSupplyChangeFactor()));
+        Decimal.D256 memory delta = limit(price.sub(baseline).div(baseline).div(calcSupplyChangeFactor()));
         uint256 newSupply = delta.mul(totalNet()).asUint256();
         (uint256 newRedeemable, uint256 lessDebt, uint256 newBonded) = increaseSupply(newSupply);
         growEpoch(delta);

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -35,7 +35,9 @@ contract Regulator is Comptroller {
         Decimal.D256 memory price = oracleCapture();
         setEpochPrice(price);
 
-        Decimal.D256 memory newMomentum = getPriceMomentum().mul(Constants.getPriceMomentumBeta()).add(price.mul(Decimal.one().sub(Constants.getPriceMomentumBeta())));
+        // When it contracts, momentum factor is decreased to account for small numbers
+        Decimal.D256 memory momentumBeta = price.greaterThan(getPriceMomentum()) ? Constants.getPriceMomentumBeta(): Constants.getPriceMomentumBeta().pow(2);
+        Decimal.D256 memory newMomentum = getPriceMomentum().mul(momentumBeta).add(price.mul(Decimal.one().sub(momentumBeta)));
         if (price.greaterThan(newMomentum)) {
             setDebtToZero();
             growSupply(price, newMomentum);
@@ -53,7 +55,7 @@ contract Regulator is Comptroller {
     }
 
     function shrinkSupply(Decimal.D256 memory price, Decimal.D256 memory baseline) private {
-        Decimal.D256 memory trueDelta = baseline.sub(price).div(calcSupplyChangeFactor());
+        Decimal.D256 memory trueDelta = baseline.sub(price).div(baseline).div(calcSupplyChangeFactor());
         Decimal.D256 memory delta = debtLimit(trueDelta);
 
         uint256 newDebt = delta.mul(totalNet()).asUint256();
@@ -65,7 +67,7 @@ contract Regulator is Comptroller {
     }
 
     function growSupply(Decimal.D256 memory price, Decimal.D256 memory baseline) private {
-        Decimal.D256 memory delta = limit(price.sub(baseline).div(calcSupplyChangeFactor()));
+        Decimal.D256 memory delta = limit(price.sub(baseline).div(price).div(calcSupplyChangeFactor()));
         uint256 newSupply = delta.mul(totalNet()).asUint256();
         (uint256 newRedeemable, uint256 lessDebt, uint256 newBonded) = increaseSupply(newSupply);
         growEpoch(delta);


### PR DESCRIPTION
Maintenance release again:
1. Momentum is more sensitive during contractions to handle small numbers better
2. Price delta was incorrectly calculated for when price is much higher than $10
3. Prepare the ability to switch to usdt oracle as price signal
4. Schedules to stop the DSD pool by epoch 150, to avoid the arb bots robbing the eth pool
verified: https://etherscan.io/address/0x32d918aAAC63ed8e55E6E321E6D79F7C10716935